### PR TITLE
update files to released npm version 0.0.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ This command will prompt you to log in using 2-factor authentication and generat
 
 2. Add the created token as a GitHub Action secret. Go to your GitHub repository, click on "Settings" > "Secrets" and then click "New repository secret". Name the secret `FIGMA_WEB_AUTHN_TOKEN` and paste the token value into the "Value" field. Click "Add secret" to save it.
 
-3. In your GitHub Action workflow file (e.g., `.github/workflows/publish.yml`), make the token available as an environment variable using the `env` keyword:
+3. Do the same for the `FIGMA_RECENT_USER_DATA` secret. This secret is used to authenticate with Figma's web API and is required for publishing plugins.
+
+4. In your GitHub Action workflow file (e.g., `.github/workflows/publish.yml`), make the token available as an environment variable using the `env` keyword:
 ```
 jobs:
     my_job:
@@ -68,6 +70,7 @@ jobs:
 
     env:
         FIGMA_WEB_AUTHN_TOKEN: ${{ secrets.FIGMA_WEB_AUTHN_TOKEN }}
+        FIGMA_RECENT_USER_DATA: ${{ secrets.FIGMA_RECENT_USER_DATA }}
 
     steps:
         # Add your other steps here
@@ -111,6 +114,7 @@ figcd current-version [options]
 **Options:**
 
 - `-t, --authn-token <string>`: Figma AuthN Token (env: FIGMA_WEB_AUTHN_TOKEN)
+- `-u, --recent-user-data <string>`: Figma Recent User Data (env: FIGMA_RECENT_USER_DATA)
 - `-m, --manifest-file <string>`: Filepath to your plugin's manifest.json (default: "./manifest.json")
 - `-h, --help`: Display help for the command.
 
@@ -126,6 +130,7 @@ figcd prepare [options]
 
 - `-p, --package-file <string>`: Filepath to your package.json (default: "package.json")
 - `-t, --authn-token <string>`: Figma AuthN Token (env: FIGMA_WEB_AUTHN_TOKEN)
+- `-u, --recent-user-data <string>`: Figma Recent User Data (env: FIGMA_RECENT_USER_DATA)
 - `-m, --manifest-file <string>`: Filepath to your plugin's manifest.json (default: "./manifest.json")
 - `-h, --help`: Display help for the command.
 
@@ -140,6 +145,7 @@ figcd create-api-key [options]
 **Options:**
 
 - `-t, --authn-token <string>`: Figma AuthN Token (env: FIGMA_WEB_AUTHN_TOKEN)
+- `-u, --recent-user-data <string>`: Figma Recent User Data (env: FIGMA_RECENT_USER_DATA)
 - `-e, --expiration <number>`: Expiration in seconds (default: 240 Seconds) (default: 240)
 - `-d, --description <string>`: Description of the token (default: "figcd-generated-token")
 - `-s, --scopes <scopes```>`: Scopes for the token (default: ["files:read"])

--- a/examples/publish.yml
+++ b/examples/publish.yml
@@ -9,6 +9,7 @@ env:
   # to create a new token run "npx figcd auth"
 env:
   FIGMA_WEB_AUTHN_TOKEN: ${{ secrets.FIGMA_WEB_AUTHN_TOKEN }}
+  FIGMA_RECENT_USER_DATA: ${{ secrets.FIGMA_RECENT_USER_DATA }}
 
 jobs:
   build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,48 +1,36 @@
 {
-  "name": "@parrots.design/parrot-cd",
-  "version": "0.0.3",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "@parrots.design/parrot-cd",
-      "version": "0.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^11.0.0",
-        "read": "^2.1.0"
-      },
-      "bin": {
-        "parrot-cd": "bin/cli.js"
-      },
-      "devDependencies": {}
-    },
-    "node_modules/commander": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/read": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/read/-/read-2.1.0.tgz",
-      "integrity": "sha512-bvxi1QLJHcaywCAEsAk4DG3nVoqiY2Csps3qzWalhj5hFqRn1d/OixkFXtLO1PrgHUcAP0FNaSY/5GYNfENFFQ==",
-      "dependencies": {
-        "mute-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    }
-  }
+  "version": "0.0.15",
+  "dependencies": {
+    "commander": "^11.0.0",
+    "read": "^2.1.0"
+  },
+  "name": "figcd",
+  "description": "Figma Plugin CLI Publisher",
+  "main": "index.js",
+  "bin": {
+    "figcd": "bin/cli.js"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/opral/parrot-figcd"
+  },
+  "keywords": [
+    "figma",
+    "cd",
+    "ci/cd",
+    "fastlane",
+    "plugin",
+    "figma-plugin",
+    "cli"
+  ],
+  "author": "Martin Lysk",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/opral/parrot-figcd"
+  },
+  "homepage": "https://github.com/opral/parrot-figcd#readme"
 }

--- a/src/auth-helper.js
+++ b/src/auth-helper.js
@@ -57,7 +57,7 @@ module.exports = {
             throw new Error('Rate limit hit... try again later');
         } else if (secondFactorTriggerLogin.status === 401) {
             console.log(secondFactorTriggerLogin.message);
-            throw new Error("Wrong credentials..." + secondFactorTriggerLogin.message);
+            throw new Error("Wrong credentials..." + JSON.stringify(secondFactorTriggerLogin) + secondFactorTriggerLogin.message);
         } else if (secondFactorTriggerLogin.status === 400
             && (secondFactorTriggerLoginResult.reason === undefined
                 || secondFactorTriggerLoginResult.reason.missing === undefined)) {

--- a/src/figma-helper.js
+++ b/src/figma-helper.js
@@ -30,12 +30,12 @@ function readJSONFile(filePath) {
 }
 
 module.exports = {
-    getFigmaApiToken: async function (authNToken, description, expiration, scopes) {
+    getFigmaApiToken: async function (authNToken, recent_user_data, description, expiration, scopes) {
         console.log(authNToken);
         const tokenResponse = await fetch('https://www.figma.com/api/user/dev_tokens', {
             "headers": {
                 "content-type": "application/json",
-                "cookie": "__Host-figma.authn=" + authNToken, // "figma.session=" + sessionToken +';',
+                "cookie": "__Host-figma.authn=" + authNToken + '; recent_user_data=' + recent_user_data +';',
                 "Referer": "https://www.figma.com/",
                 "Referrer-Policy": "origin-when-cross-origin"
             },
@@ -56,8 +56,10 @@ module.exports = {
         const pluginId = manifest.id;
         const pluginsResponse = await fetch("https://www.figma.com/api/plugins", {
             "headers": {
+                "accept": "application/json",
                 "content-type": "application/json",
-                "cookie": "__Host-figma.authn=" + authNToken, // "figma.session=" + sessionToken +';',
+                "cookie": "__Host-figma.authn=" + authNToken + '; recent_user_data=' + recent_user_data +';',
+                "user-agent": 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
                 "Referer": "https://www.figma.com/",
                 "Referrer-Policy": "origin-when-cross-origin"
             },
@@ -82,13 +84,16 @@ module.exports = {
         return currentVersionNumber;
     },
 
-    getPluginInfo: async function (manifestFile, authNToken) {
+    getPluginInfo: async function (manifestFile, authNToken, recent_user_data) {
         const manifest = await readJSONFile(manifestFile);
+        console.log('header '+ "__Host-figma.authn=" + authNToken + '; recent_user_data=' + recent_user_data +';',)
         const pluginId = manifest.id;
         const pluginsResponse = await fetch("https://www.figma.com/api/plugins", {
             "headers": {
+                "accept": "application/json",
                 "content-type": "application/json",
-                "cookie": "__Host-figma.authn=" + authNToken, // "figma.session=" + sessionToken +';',
+                "cookie": "__Host-figma.authn=" + authNToken + '; recent_user_data=' + recent_user_data +';',
+                "user-agent": 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
                 "Referer": "https://www.figma.com/",
                 "Referrer-Policy": "origin-when-cross-origin"
             },
@@ -114,15 +119,17 @@ module.exports = {
         return pluginMeta;
     },
 
-    prepareRelease: async function (manifestFile, name, description, releaseNotes, tagline, tags, authNToken ) {
+    prepareRelease: async function (manifestFile, name, description, releaseNotes, tagline, tags, authNToken, recent_user_data ) {
         const manifest = await readJSONFile(manifestFile);
         
         const prepareReleaseResponse = await fetch("https://www.figma.com/api/plugins/"+manifest.id+"/upload", {
             "headers": {
+                "accept": "application/json",
                 "content-type": "application/json",
-                "cookie": "__Host-figma.authn=" + authNToken, // "figma.session=" + sessionToken +';',
+                "cookie": "__Host-figma.authn=" + authNToken + '; recent_user_data=' + recent_user_data +';',
+                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
                 "Referer": "https://www.figma.com/",
-                "Referrer-Policy": "origin-when-cross-origin"
+                "Referrer-Policy": "origin-when-cross-origin",
             },
             "body": JSON.stringify({
                 "manifest": manifest,
@@ -174,15 +181,17 @@ module.exports = {
         }
     },
 
-    publishRelease: async function(manifestFile, preparedVersionId, signature, authNToken) {
+    publishRelease: async function(manifestFile, preparedVersionId, signature, authNToken, recent_user_data) {
         const manifest = await readJSONFile(manifestFile);
 
         let publishRequest = await fetch("https://www.figma.com/api/plugins/"+manifest.id+"/versions/" + preparedVersionId, {
             "headers": {
+                "accept": "application/json",
                 "content-type": "application/json",
-                "cookie": "__Host-figma.authn=" + authNToken, // "figma.session=" + sessionToken +';',
+                "cookie": "__Host-figma.authn=" + authNToken + '; recent_user_data=' + recent_user_data +';',
+                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
                 "Referer": "https://www.figma.com/",
-                "Referrer-Policy": "origin-when-cross-origin"
+                "Referrer-Policy": "origin-when-cross-origin",
             },
             body: JSON.stringify({
                 "agreed_to_tos": true,

--- a/src/package-json-helper.js
+++ b/src/package-json-helper.js
@@ -12,4 +12,3 @@ module.exports = {
     fs.writeFileSync(packageFile, JSON.stringify({ ...packageData, version: updatedVersion }, null, 2), 'utf8');
 }
 }
-

--- a/src/publish-release.js
+++ b/src/publish-release.js
@@ -42,7 +42,7 @@ async function runCLI() {
     console.log('Uploading code bundle.... done');
 
     console.log('Releasing prepared version (' + preparedRelease.version_id + ')');
-    const publishedVersion = await publishRelease(manifestPath, preparedVersionId, signature, authNToken);
+    const publishedVersion = await publishRelease(manifestPath, preparedVersionId, signature, authNToken, recent_user_data);
     
     console.log('Version '+ publishedVersion.plugin.versions[preparedVersionId].version +' (' + preparedVersionId + ') published');
   


### PR DESCRIPTION
I released version 0.0.15 from my local machine, but I had no write access during that time. The npm version got out of sync and I copied the changes back into the repo.
Additionally, I added some documentation and updated the example action workflow.

Either we continue with this version or we add the whole cookie as in https://github.com/opral/parrot-figcd/pull/5.