### PR TITLE
Add category and subcategory options to figcd release command

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ figcd release [options]
 - `-c, --enable-comments <boolean>`: Enable Comments - falling back to the current ones in the store if not specified
 - `-rn, --release-notes <string>`: Release Notes (default: "")
 - `-rnf, --release-notes-file <string>`: Release Notes file containing the description of what has changed - {{VERSION}} will be replaced with the version of the Figma plugin
+- `-cat, --category <string>`: Category of the Figma plugin
+- `-subcat, --subcategory <string>`: Subcategory of the Figma plugin
 - `-h, --help`: Display help for the command.
 
 ## Options

--- a/src/figma-helper.js
+++ b/src/figma-helper.js
@@ -180,7 +180,7 @@ module.exports = {
         return categoriesJson.meta;
     },
 
-    prepareRelease: async function (manifestFile, name, description, releaseNotes, tagline, tags, authNToken, category, cookie, imagesSha1) {
+    prepareRelease: async function (manifestFile, name, description, releaseNotes, tagline, tags, authNToken, category, subcategory) {
         const manifest = await readJSONFile(manifestFile);
         
         const prepareReleaseResponse = await fetch("https://www.figma.com/api/plugins/"+manifest.id+"/upload", {
@@ -189,7 +189,7 @@ module.exports = {
                 "content-type": "application/json",
                 "cookie": serializeCookies({
                     "__Host-figma.authn": authNToken,
-                }, cookie),
+                }),
                 'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
                 "Referer": "https://www.figma.com/",
                 "Referrer-Policy": "origin-when-cross-origin",
@@ -199,11 +199,10 @@ module.exports = {
                 "release_notes": releaseNotes,
                 "name": name,
                 "description": description,
-                "images_sha1": imagesSha1,
                 "tagline": tagline,
-                "creator_policy": "",
                 "tags": tags.map(tag => tag.toLowerCase()),
-                "category_id": category
+                "category": category,
+                "subcategory": subcategory
             }),
             method: 'POST'
         });

--- a/src/publish-release.js
+++ b/src/publish-release.js
@@ -36,9 +36,11 @@ async function runCLI() {
     const description = getText('plugin_store_description', 'en', figmaDocument);
     const tagline = getText('plugin_store_tagline', 'en', figmaDocument);
     const name = getText('plugin_store_product_name', 'en', figmaDocument);
+    const category = getText('plugin_store_category', 'en', figmaDocument);
+    const subcategory = getText('plugin_store_subcategory', 'en', figmaDocument);
     
     console.log('Preparing release...');
-    const preparedRelease = await prepareRelease(manifestPath, name, description, tagline, tags, authNToken);
+    const preparedRelease = await prepareRelease(manifestPath, name, description, tagline, tags, authNToken, category, subcategory);
     
     const preparedVersionId = preparedRelease.version_id;
     const signature = preparedRelease.signature;


### PR DESCRIPTION
Add support for specifying category and subcategory options for plugin release.

* Modify `prepareRelease` function in `src/figma-helper.js` to include `category` and `subcategory` parameters and update the request body accordingly.
* Update `src/publish-release.js` to handle `category` and `subcategory` options and pass them to the `prepareRelease` function.
* Update `README.md` to include documentation for `category` and `subcategory` options for the `release` command.

