### PR TITLE
Fix file resolution relative to manifest.json

### DIFF
--- a/src/figma-helper.js
+++ b/src/figma-helper.js
@@ -216,8 +216,8 @@ module.exports = {
     uploadCodeBundle: async function(manifestFile, codeUploadInfo) {
         const manifest = await readJSONFile(manifestFile);
 
-        const main = fs.readFileSync(path.resolve(manifest.main), 'utf8');
-        const ui = fs.readFileSync(path.resolve(manifest.ui), 'utf8');
+        const main = fs.readFileSync(path.resolve(path.join(path.dirname(manifestFile), manifest.main)), 'utf8');
+        const ui = fs.readFileSync(path.resolve(path.join(path.dirname(manifestFile), manifest.ui)), 'utf8');
     
         const codeBundle = createPluginBundle(main, ui);
     


### PR DESCRIPTION
Fixes #9

Update `uploadCodeBundle` function to resolve file paths relative to `manifest.json`.

* Change the `main` file path resolution to be relative to the `manifest.json` file.
* Change the `ui` file path resolution to be relative to the `manifest.json` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/opral/parrot-figcd/pull/10?shareId=45897cab-1bbd-4b67-a122-e489c0e13028).