### PR TITLE
Throw if error

### DIFF
--- a/src/figma-helper.js
+++ b/src/figma-helper.js
@@ -210,6 +210,10 @@ module.exports = {
 
         const responseJson = await prepareReleaseResponse.json();
 
+        if (responseJson.error) {
+            throw responseJson.message;
+        }
+
         return (responseJson).meta;
     },
 


### PR DESCRIPTION
Not checking the error state of the response leads to difficult to debug behavior (see #1). Checking and throwing if error should make things more obvious when something is going wrong.

